### PR TITLE
Add magic link route and CLI

### DIFF
--- a/api/routes/magic.js
+++ b/api/routes/magic.js
@@ -1,0 +1,68 @@
+// api/routes/magic.js
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const mongoose = require('mongoose');
+
+const router = express.Router();
+
+const MAGIC_SECRET = process.env.MAGIC_LINK_SECRET || process.env.JWT_SECRET;
+
+// Reuse your existing User model registered by the app
+// e.g., const User = mongoose.model('User'); (we'll query inside handler)
+
+// Set cookies similar to normal login
+function setAuthCookies(res, accessToken, refreshToken) {
+  const base = {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: true, // Heroku uses HTTPS
+    path: '/',
+  };
+  // cover common cookie names used by different builds
+  res.cookie('token', accessToken, base);
+  res.cookie('jwt', accessToken, base);
+  res.cookie('accessToken', accessToken, base);
+  if (refreshToken) res.cookie('refreshToken', refreshToken, base);
+}
+
+// PUBLIC: consume the magic link → set cookies → redirect to app
+// GET /m/:token
+router.get('/m/:token', async (req, res) => {
+  try {
+    const { token } = req.params;
+    const payload = jwt.verify(token, MAGIC_SECRET, { audience: 'magic-link' });
+    const userId = payload.sub;
+
+    const User = mongoose.model('User');
+    const user = await User.findById(userId);
+    if (!user) return res.status(404).send('User not found');
+
+    // access token
+    const access = jwt.sign(
+      { sub: userId, id: userId, _id: userId, email: user.email },
+      process.env.JWT_SECRET,
+      { expiresIn: process.env.JWT_EXPIRES_IN || '1h' },
+    );
+
+    // refresh token (fallback to other names if needed)
+    const refreshSecret =
+      process.env.REFRESH_TOKEN_SECRET ||
+      process.env.JWT_REFRESH_SECRET ||
+      process.env.JWT_SECRET;
+
+    const refresh = jwt.sign(
+      { sub: userId },
+      refreshSecret,
+      { expiresIn: process.env.REFRESH_TOKEN_EXPIRES_IN || '30d' },
+    );
+
+    setAuthCookies(res, access, refresh);
+
+    // land straight in the app
+    return res.redirect('/');
+  } catch (e) {
+    return res.status(401).send('Invalid or expired link');
+  }
+});
+
+module.exports = router;

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -22,6 +22,7 @@ const staticCache = require('./utils/staticCache');
 const noIndex = require('./middleware/noIndex');
 const routes = require('./routes');
 const adminUsers = require('../routes/admin.users');
+const magicRoutes = require('../routes/magic');
 
 const { PORT, HOST, ALLOW_SOCIAL_LOGIN, DISABLE_COMPRESSION, TRUST_PROXY } = process.env ?? {};
 
@@ -122,6 +123,8 @@ const startServer = async () => {
 
   app.use('/api/tags', routes.tags);
   app.use('/api/mcp', routes.mcp);
+
+  app.use('/', magicRoutes);
 
   app.use(ErrorController);
 

--- a/config/make-magic-link.js
+++ b/config/make-magic-link.js
@@ -1,0 +1,52 @@
+// config/make-magic-link.js
+require('dotenv').config();
+const jwt = require('jsonwebtoken');
+const mongoose = require('mongoose');
+
+(async () => {
+  const MONGO = process.env.MONGO_URI || process.env.MONGODB_URI;
+  const MAGIC_SECRET = process.env.MAGIC_LINK_SECRET || process.env.JWT_SECRET;
+  const PUBLIC_URL = process.env.PUBLIC_URL;
+
+  if (!MONGO) throw new Error('MONGO_URI not set');
+  if (!MAGIC_SECRET) throw new Error('MAGIC_LINK_SECRET (or JWT_SECRET) not set');
+  if (!PUBLIC_URL) throw new Error('PUBLIC_URL not set');
+
+  await mongoose.connect(MONGO, {});
+  const User = mongoose.model('User', new mongoose.Schema({}, { strict: false, collection: 'users' }));
+
+  // very simple arg parsing: --email ... OR --userId ... [--ttl 30d]
+  const args = process.argv.slice(2);
+  const get = (k, d) => {
+    const i = args.indexOf(k);
+    return i >= 0 ? args[i + 1] : d;
+  };
+  const email = get('--email');
+  const userId = get('--userId');
+  const ttl = get('--ttl', '30d');
+
+  if (!email && !userId) {
+    console.error('Usage: node config/make-magic-link.js --email someone@x.com [--ttl 30d]');
+    console.error('   or: node config/make-magic-link.js --userId <mongo_id> [--ttl 30d]');
+    process.exit(1);
+  }
+
+  const user = userId
+    ? await User.findById(userId)
+    : await User.findOne({ email: String(email).toLowerCase() });
+
+  if (!user) {
+    console.error('User not found');
+    process.exit(2);
+  }
+
+  const token = jwt.sign(
+    { sub: String(user._id), typ: 'magic' },
+    MAGIC_SECRET,
+    { expiresIn: ttl, audience: 'magic-link' },
+  );
+
+  const url = `${PUBLIC_URL}/m/${token}`;
+  console.log(JSON.stringify({ url, userId: user._id }, null, 2));
+  process.exit(0);
+})().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add public magic link route that verifies token, sets auth cookies, and redirects to app
- mount new route before the catch-all in server index
- add CLI script for generating magic link URLs for users

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:api` *(fails: Cannot find module '@librechat/data-schemas', etc.)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9e5014568832a826c04d5a8f41dac