### PR TITLE
fix: include credentials in axios requests

### DIFF
--- a/packages/data-provider/src/actions.ts
+++ b/packages/data-provider/src/actions.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import _axios from 'axios';
+_axios.defaults.withCredentials = true;
 import { URL } from 'url';
 import crypto from 'crypto';
 import { load } from 'js-yaml';

--- a/packages/data-provider/src/headers-helpers.ts
+++ b/packages/data-provider/src/headers-helpers.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+axios.defaults.withCredentials = true;
 
 export function setAcceptLanguageHeader(value: string): void {
   axios.defaults.headers.common['Accept-Language'] = value;

--- a/packages/data-provider/src/request.ts
+++ b/packages/data-provider/src/request.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import axios, { AxiosError, AxiosRequestConfig } from 'axios';
+axios.defaults.withCredentials = true;
 import * as endpoints from './api-endpoints';
 import { setTokenHeader } from './headers-helpers';
 import type * as t from './types';


### PR DESCRIPTION
## Summary
- send cookies with axios calls to maintain magic link sessions
- ensure axios instances default to `withCredentials`

## Testing
- `cd packages/data-provider && npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68aa0ddf9284832a9d608be517d6cb0a