### PR TITLE
Revert problematic login fix

### DIFF
--- a/api/server/index.js
+++ b/api/server/index.js
@@ -11,7 +11,6 @@ const passport = require('passport');
 const compression = require('compression');
 const cookieParser = require('cookie-parser');
 const mongoSanitize = require('express-mongo-sanitize');
-const jwt = require('jsonwebtoken'); // <-- NEW
 
 const { logger } = require('@librechat/data-schemas');
 const { isEnabled, ErrorController } = require('@librechat/api');
@@ -104,20 +103,6 @@ const startServer = async () => {
   if (isEnabled(ALLOW_SOCIAL_LOGIN)) {
     await configureSocialLogins(app);
   }
-
-  // ✅ Session shim: report "logged in" if a valid Bearer JWT is present.
-  //    MUST be before mounting routes.auth so SPA boot doesn't 401.
-  app.get('/api/auth/session', (req, res, next) => {
-    try {
-      const h = req.headers.authorization || '';
-      const token = h.startsWith('Bearer ') ? h.slice(7) : null;
-      if (!token) return next();
-      jwt.verify(token, process.env.JWT_SECRET);
-      return res.status(200).json({ ok: true, authenticated: true });
-    } catch {
-      return next();
-    }
-  });
 
   /* API Endpoints */
   app.use('/oauth', routes.oauth);

--- a/packages/data-provider/src/actions.ts
+++ b/packages/data-provider/src/actions.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import _axios from 'axios';
-_axios.defaults.withCredentials = true;
 import { URL } from 'url';
 import crypto from 'crypto';
 import { load } from 'js-yaml';

--- a/packages/data-provider/src/headers-helpers.ts
+++ b/packages/data-provider/src/headers-helpers.ts
@@ -1,5 +1,4 @@
 import axios from 'axios';
-axios.defaults.withCredentials = true;
 
 export function setAcceptLanguageHeader(value: string): void {
   axios.defaults.headers.common['Accept-Language'] = value;

--- a/packages/data-provider/src/request.ts
+++ b/packages/data-provider/src/request.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import axios, { AxiosError, AxiosRequestConfig } from 'axios';
-axios.defaults.withCredentials = true;
 import * as endpoints from './api-endpoints';
 import { setTokenHeader } from './headers-helpers';
 import type * as t from './types';


### PR DESCRIPTION
## Summary
- revert session shim and JWT import in API server
- remove `withCredentials` defaults from data provider axios setup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(terminated: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68aa114b0c60832aa6152f750fbc21d1