### PR TITLE
fix: correct admin users import path

### DIFF
--- a/api/server/index.js
+++ b/api/server/index.js
@@ -23,7 +23,7 @@ const noIndex = require('./middleware/noIndex');
 const routes = require('./routes');
 
 const { PORT, HOST, ALLOW_SOCIAL_LOGIN, DISABLE_COMPRESSION, TRUST_PROXY } = process.env ?? {};
-import adminUsers from '../routes/admin.users';
+const adminUsers = require('../routes/admin.users');
   
 // Allow PORT=0 to be used for automatic free port assignment
 const port = isNaN(Number(PORT)) ? 3080 : Number(PORT);


### PR DESCRIPTION
## Summary
- use CommonJS require for admin users route in server

## Testing
- `npm test` *(fails: Cannot find module '@librechat/data-schemas')*

------
https://chatgpt.com/codex/tasks/task_e_68ac7b9f7fd4832ab9f06b377add7feb