### PR TITLE
Restrict assistant binding to admin API key

### DIFF
--- a/api/server/routes/assistants/bind.js
+++ b/api/server/routes/assistants/bind.js
@@ -2,17 +2,22 @@ const express = require('express');
 const { AssistantBinding } = require('~/mongo/models/AssistantBinding');
 
 const router = express.Router();
+const ADMIN_KEY = process.env.ADMIN_API_KEY;
 
 /**
  * Bind a Libre user to an OpenAI assistant.
  *
  * @route POST /assistants/bind
  * @example curl -X POST https://librechat.example.com/api/assistants/bind \
- *  -H "Authorization: Bearer <TOKEN>" \
+ *  -H "x-admin-key: <ADMIN_API_KEY>" \
  *  -H "Content-Type: application/json" \
  *  -d '{"libre_user_id":"6653f1a0e2...","assistant_id":"asst_abc123xyz"}'
  */
 router.post('/', async (req, res) => {
+  if (!ADMIN_KEY || req.headers['x-admin-key'] !== ADMIN_KEY) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+
   const { libre_user_id, assistant_id } = req.body || {};
 
   if (!libre_user_id || typeof libre_user_id !== 'string') {
@@ -33,4 +38,3 @@ router.post('/', async (req, res) => {
 });
 
 module.exports = router;
-

--- a/api/server/routes/assistants/index.js
+++ b/api/server/routes/assistants/index.js
@@ -9,11 +9,13 @@ const chatV1 = require('./chatV1');
 const v2 = require('./v2');
 const chatV2 = require('./chatV2');
 
-router.use(requireJwtAuth);
 router.use(checkBan);
 router.use(uaParser);
 
 router.use('/bind', bind);
+
+router.use(requireJwtAuth);
+
 router.post('/chat', postMessageViaAssistant);
 
 router.use('/v1/', v1);


### PR DESCRIPTION
## Summary
- Protect assistant binding endpoint with `x-admin-key` header instead of JWT auth
- Exempt `/assistants/bind` from global JWT middleware while leaving other assistant routes protected

## Testing
- `npx eslint api/server/routes/assistants/bind.js api/server/routes/assistants/index.js`
- `npm run test:api` *(fails: Cannot find module 'librechat-data-provider'; MongoDB download 403)*

------
https://chatgpt.com/codex/tasks/task_e_68add83ac32c832a90eaca7cafe2fb06