### PR TITLE
Gracefully handle missing RAG API URL

### DIFF
--- a/api/server/services/start/checks.js
+++ b/api/server/services/start/checks.js
@@ -71,14 +71,21 @@ function checkVariables() {
  * Logs information or warning based on the API's availability and response.
  */
 async function checkHealth() {
+  const ragUrl = process.env.RAG_API_URL;
+
+  if (!ragUrl) {
+    logger.warn('RAG API URL is not defined; file uploads may be disabled.');
+    return;
+  }
+
   try {
-    const response = await fetch(`${process.env.RAG_API_URL}/health`);
+    const response = await fetch(`${ragUrl}/health`);
     if (response?.ok && response?.status === 200) {
-      logger.info(`RAG API is running and reachable at ${process.env.RAG_API_URL}.`);
+      logger.info(`RAG API is running and reachable at ${ragUrl}.`);
     }
-  } catch (error) {
+  } catch (_error) {
     logger.warn(
-      `RAG API is either not running or not reachable at ${process.env.RAG_API_URL}, you may experience errors with file uploads.`,
+      `RAG API is either not running or not reachable at ${ragUrl}, you may experience errors with file uploads.`,
     );
   }
 }


### PR DESCRIPTION
## Summary
- avoid RAG health check when `RAG_API_URL` is unset
- improve warning messages when RAG service is unavailable

## Testing
- `npx eslint api/server/services/start/checks.js`
- `npm run test:api` *(fails: Cannot find module '@librechat/data-schemas')*


------
https://chatgpt.com/codex/tasks/task_e_68adde804ebc832aa9ec310c961c314a