### PR TITLE
chore: add bind troubleshooting logs

### DIFF
--- a/api/server/routes/assistants/bind.js
+++ b/api/server/routes/assistants/bind.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { AssistantBinding } = require('~/mongo/models/AssistantBinding');
+const { logger } = require('~/config');
 
 const router = express.Router();
 const ADMIN_KEY = process.env.ADMIN_API_KEY;
@@ -14,27 +15,37 @@ const ADMIN_KEY = process.env.ADMIN_API_KEY;
  *  -d '{"libre_user_id":"6653f1a0e2...","assistant_id":"asst_abc123xyz"}'
  */
 router.post('/', async (req, res) => {
-  if (!ADMIN_KEY || req.headers['x-admin-key'] !== ADMIN_KEY) {
-    return res.status(401).json({ error: 'unauthorized' });
+  logger.debug('[/assistants/bind] Request body:', req.body);
+  try {
+    if (!ADMIN_KEY || req.headers['x-admin-key'] !== ADMIN_KEY) {
+      logger.warn('[/assistants/bind] Unauthorized request');
+      return res.status(401).json({ error: 'unauthorized' });
+    }
+
+    const { libre_user_id, assistant_id } = req.body || {};
+
+    if (!libre_user_id || typeof libre_user_id !== 'string') {
+      logger.warn('[/assistants/bind] Missing or invalid libre_user_id', { libre_user_id });
+      return res.status(400).json({ error: 'missing_libre_user_id' });
+    }
+
+    if (!assistant_id || !assistant_id.startsWith('asst_')) {
+      logger.warn('[/assistants/bind] Invalid assistant_id', { assistant_id });
+      return res.status(400).json({ error: 'invalid_assistant_id' });
+    }
+
+    await AssistantBinding.updateOne(
+      { user: libre_user_id },
+      { $set: { assistant_id }, $setOnInsert: { createdAt: new Date() } },
+      { upsert: true },
+    );
+
+    logger.info('[/assistants/bind] Bound user to assistant', { libre_user_id, assistant_id });
+    res.json({ ok: true });
+  } catch (error) {
+    logger.error('[/assistants/bind] Error binding assistant', error);
+    res.status(500).json({ error: 'internal_server_error' });
   }
-
-  const { libre_user_id, assistant_id } = req.body || {};
-
-  if (!libre_user_id || typeof libre_user_id !== 'string') {
-    return res.status(400).json({ error: 'missing_libre_user_id' });
-  }
-
-  if (!assistant_id || !assistant_id.startsWith('asst_')) {
-    return res.status(400).json({ error: 'invalid_assistant_id' });
-  }
-
-  await AssistantBinding.updateOne(
-    { user: libre_user_id },
-    { $set: { assistant_id }, $setOnInsert: { createdAt: new Date() } },
-    { upsert: true },
-  );
-
-  res.json({ ok: true });
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add winston logger to assistants bind endpoint
- log request body and common validation failures
- handle errors and log successful bindings

## Testing
- `npm run test:api` *(fails: Cannot find module '@librechat/api')*
- `npx eslint api/server/routes/assistants/bind.js -f json`


------
https://chatgpt.com/codex/tasks/task_e_68ade12266ec832aa7591039d7017271