### PR TITLE
Disable private assistants filtering

### DIFF
--- a/librechat.yaml
+++ b/librechat.yaml
@@ -7,3 +7,6 @@ endpoints:
     apiKey: ${OPENAI_API_KEY}
     headers:
       OpenAI-Beta: assistants=v2
+
+assistants:
+  privateAssistants: false


### PR DESCRIPTION
## Summary
- disable private assistant filtering in configuration to show all assistants

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68adfb6ea464832abd47498cec21596d