### PR TITLE
Add debug logging for model selection and assistant binding

### DIFF
--- a/api/server/controllers/ModelController.js
+++ b/api/server/controllers/ModelController.js
@@ -40,6 +40,10 @@ async function loadModels(req) {
 async function modelController(req, res) {
   try {
     const modelConfig = await loadModels(req);
+    logger.debug('[modelController] Returning models', {
+      userId: req.user?.id,
+      modelConfig,
+    });
     res.send(modelConfig);
   } catch (error) {
     logger.error('Error fetching models:', error);

--- a/api/server/services/Config/loadDefaultModels.js
+++ b/api/server/services/Config/loadDefaultModels.js
@@ -47,7 +47,7 @@ async function loadDefaultModels(req) {
         }),
       ]);
 
-    return {
+    const modelMap = {
       [EModelEndpoint.openAI]: openAI,
       [EModelEndpoint.google]: google,
       [EModelEndpoint.anthropic]: anthropic,
@@ -56,6 +56,9 @@ async function loadDefaultModels(req) {
       [EModelEndpoint.azureAssistants]: azureAssistants,
       [EModelEndpoint.bedrock]: bedrock,
     };
+
+    logger.debug('[loadDefaultModels] Loaded models', modelMap);
+    return modelMap;
   } catch (error) {
     logger.error('Error fetching default models:', error);
     throw new Error(`Failed to load default models: ${error.message}`);

--- a/api/server/services/assistants.js
+++ b/api/server/services/assistants.js
@@ -1,12 +1,19 @@
 const { AssistantBinding } = require('~/mongo/models/AssistantBinding');
 const { ThreadBinding } = require('~/mongo/models/ThreadBinding');
 const { openai } = require('./openai');
+const { logger } = require('~/config');
 
 async function getAssistantIdForUser(libreUserId) {
+  logger.debug('[assistants] fetching assistant for user', { libreUserId });
   const row = await AssistantBinding.findOne({ user: libreUserId }).lean();
   if (!row || !row.assistant_id) {
+    logger.warn('[assistants] assistant not configured for user', { libreUserId });
     throw new Error('assistant_not_configured');
   }
+  logger.debug('[assistants] found assistant', {
+    libreUserId,
+    assistantId: row.assistant_id,
+  });
   return row.assistant_id;
 }
 


### PR DESCRIPTION
## Summary
- log loaded model lists in default model loader
- log returned model configuration per user
- add assistant binding debug logs for retrieval and absence

## Testing
- `npm run test:api` *(fails: Cannot find module '@librechat/api')*

------
https://chatgpt.com/codex/tasks/task_e_68ae917de61c832aa44b905f547785de