### PR TITLE
Fix agent server URL handling

### DIFF
--- a/packages/data-provider/specs/createPayload.spec.ts
+++ b/packages/data-provider/specs/createPayload.spec.ts
@@ -1,0 +1,44 @@
+import createPayload from '../src/createPayload';
+import { EModelEndpoint } from '../src/schemas';
+import type { TSubmission } from '../src/types';
+
+describe('createPayload server URL', () => {
+  const base = {
+    userMessage: {
+      messageId: '1',
+      conversationId: 'c1',
+      parentMessageId: null,
+      text: 'Hello',
+      isCreatedByUser: true,
+    },
+    isTemporary: false,
+    messages: [],
+    conversation: {
+      conversationId: 'c1',
+      endpoint: EModelEndpoint.agents,
+      title: 'New Chat',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  };
+
+  it('posts agent requests to /api/agents/chat', () => {
+    const submission: TSubmission = {
+      ...base,
+      endpointOption: { endpoint: EModelEndpoint.agents },
+    };
+
+    const { server } = createPayload(submission);
+    expect(server).toBe('/api/agents/chat');
+  });
+
+  it('appends endpoint when not agents', () => {
+    const submission: TSubmission = {
+      ...base,
+      endpointOption: { endpoint: EModelEndpoint.openAI },
+    };
+
+    const { server } = createPayload(submission);
+    expect(server).toBe(`/api/agents/chat/${EModelEndpoint.openAI}`);
+  });
+});

--- a/packages/data-provider/src/createPayload.ts
+++ b/packages/data-provider/src/createPayload.ts
@@ -21,7 +21,10 @@ export default function createPayload(submission: t.TSubmission) {
   };
 
   const endpoint = _e as s.EModelEndpoint;
-  let server = `${EndpointURLs[s.EModelEndpoint.agents]}/${endpoint}`;
+  let server = EndpointURLs[s.EModelEndpoint.agents];
+  if (endpoint !== s.EModelEndpoint.agents) {
+    server += `/${endpoint}`;
+  }
   if (s.isAssistantsEndpoint(endpoint)) {
     server =
       EndpointURLs[(endpointType ?? endpoint) as 'assistants' | 'azureAssistants'] +


### PR DESCRIPTION
## Summary
- build agent server URL from base `/api/agents/chat` and only append provider when necessary
- add tests verifying agent requests hit `/api/agents/chat`

## Testing
- `npx eslint packages/data-provider/src/createPayload.ts packages/data-provider/specs/createPayload.spec.ts`
- `npm --prefix packages/data-provider run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68aed124811c832a89d180d810a8dd9a