### PR TITLE
chore: expand ACL debug logging

### DIFF
--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -448,6 +448,13 @@ const getListAgentsHandler = async (req, res) => {
       resourceType: ResourceType.AGENT,
       requiredPermissions: requiredPermission,
     });
+    logger.debug('[getListAgents] accessible resources', {
+      userId,
+      accessibleIds,
+      accessibleCount: accessibleIds.length,
+      filter,
+      requiredPermission,
+    });
     const publiclyAccessibleIds = await findPubliclyAccessibleResources({
       resourceType: ResourceType.AGENT,
       requiredPermissions: PermissionBits.VIEW,
@@ -458,6 +465,10 @@ const getListAgentsHandler = async (req, res) => {
       otherParams: filter,
       limit,
       after: cursor,
+    });
+    logger.debug('[getListAgents] fetched agents', {
+      userId,
+      returned: data?.data?.length ?? 0,
     });
     if (data?.data?.length) {
       data.data = data.data.map((agent) => {


### PR DESCRIPTION
## Summary
- add debug logs in PermissionService for principals and public access queries
- log ACL query and results in data-schemas `findAccessibleResources`

## Testing
- `npm run test:api` *(fails: Cannot find module '@librechat/data-schemas')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aed83d90b8832a97352991244c9272