### PR TITLE
chore: log agent data when listing

### DIFF
--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -455,12 +455,17 @@ export const deleteAgent = ({ agent_id }: m.DeleteAgentBody): Promise<void> => {
   );
 };
 
-export const listAgents = (params: a.AgentListParams): Promise<a.AgentListResponse> => {
-  return request.get(
+export const listAgents = async (
+  params: a.AgentListParams,
+): Promise<a.AgentListResponse> => {
+  const res = await request.get(
     endpoints.agents({
       options: params,
     }),
   );
+
+  console.log('Agent data loaded:', res.agents);
+  return res;
 };
 
 export const revertAgentVersion = ({


### PR DESCRIPTION
## Summary
- log the agent array fetched from the server when listing agents to debug loading issues

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af08d19efc832a82be34c524e73d5d