### PR TITLE
fix: specify agent response type

### DIFF
--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -455,16 +455,14 @@ export const deleteAgent = ({ agent_id }: m.DeleteAgentBody): Promise<void> => {
   );
 };
 
-export const listAgents = async (
-  params: a.AgentListParams,
-): Promise<a.AgentListResponse> => {
-  const res = await request.get(
+export const listAgents = async (params: a.AgentListParams): Promise<a.AgentListResponse> => {
+  const res = await request.get<a.AgentListResponse>(
     endpoints.agents({
       options: params,
     }),
   );
 
-  console.log('Agent data loaded:', res.agents);
+  console.log('Agent data loaded:', res.data);
   return res;
 };
 
@@ -496,7 +494,7 @@ export const getMarketplaceAgents = (params: {
   cursor?: string;
   promoted?: 0 | 1;
 }): Promise<a.AgentListResponse> => {
-  return request.get(
+  return request.get<a.AgentListResponse>(
     endpoints.agents({
       // path: 'marketplace',
       options: params,


### PR DESCRIPTION
## Summary
- ensure agent response is typed and logged correctly
- type marketplace agent requests

## Testing
- `npx eslint packages/data-provider/src/data-service.ts`
- `cd packages/data-provider && npm run test:ci`
- `cd packages/data-provider && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af0de0b604832a9892904bb5514513