### PR TITLE
Guard speech settings from redundant updates

### DIFF
--- a/client/src/hooks/Config/useSpeechSettingsInit.ts
+++ b/client/src/hooks/Config/useSpeechSettingsInit.ts
@@ -43,7 +43,7 @@ export default function useSpeechSettingsInit(isAuthenticated: boolean) {
       const setter = setters[key as keyof typeof setters];
       if (setter) {
         logger.log(`Setting default speech setting: ${key} = ${value}`);
-        setter(value as any);
+        setter((prev: unknown) => (Object.is(prev, value) ? prev : (value as any)));
       }
     });
   }, [isAuthenticated, data, setters]);


### PR DESCRIPTION
## Summary
- avoid resetting speech configuration atoms when the value hasn't changed

## Testing
- `npm run test:client` *(fails: Cannot find module 'librechat-data-provider')*


------
https://chatgpt.com/codex/tasks/task_e_68b01201ad58832a89486d5d13609232