### PR TITLE
Revert speech settings guard

### DIFF
--- a/client/src/hooks/Config/useSpeechSettingsInit.ts
+++ b/client/src/hooks/Config/useSpeechSettingsInit.ts
@@ -43,7 +43,7 @@ export default function useSpeechSettingsInit(isAuthenticated: boolean) {
       const setter = setters[key as keyof typeof setters];
       if (setter) {
         logger.log(`Setting default speech setting: ${key} = ${value}`);
-        setter((prev: unknown) => (Object.is(prev, value) ? prev : (value as any)));
+        setter(value as any);
       }
     });
   }, [isAuthenticated, data, setters]);


### PR DESCRIPTION
## Summary
- revert redundant speech settings guard that didn't resolve crash

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (incomplete: process terminated)
- `npm run test:api` (fails: missing `@librechat/data-schemas` module)

------
https://chatgpt.com/codex/tasks/task_e_68b024f9a924832aa6b0a4f727c6e0a7