### PR TITLE
fix: use relative http client import

### DIFF
--- a/client/src/pages/AgentsList.tsx
+++ b/client/src/pages/AgentsList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getJSON } from '@/lib/http-client';
+import { getJSON } from '../lib/http-client';
 
 export default function AgentsList() {
   const [agents, setAgents] = useState<any[]>([]);


### PR DESCRIPTION
## Summary
- fix AgentsList http-client import to use relative path

## Testing
- `npm run test:client` *(fails: Cannot find module 'librechat-data-provider', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b06e7a62b4832aa3e96454ce9a5fcc