### PR TITLE
Normalize API error responses and add safe fetch helper

### DIFF
--- a/api/server/index.js
+++ b/api/server/index.js
@@ -10,7 +10,7 @@ const compression = require('compression');
 const cookieParser = require('cookie-parser');
 const { logger } = require('@librechat/data-schemas');
 const mongoSanitize = require('express-mongo-sanitize');
-const { isEnabled, ErrorController } = require('@librechat/api');
+const { isEnabled } = require('@librechat/api');
 const { connectDb, indexSync } = require('~/db');
 const validateImageRequest = require('./middleware/validateImageRequest');
 const { jwtLogin, ldapLogin, passportLogin } = require('~/strategies');
@@ -122,8 +122,15 @@ const startServer = async () => {
 
   app.use('/api/tags', routes.tags);
   app.use('/api/mcp', routes.mcp);
+  app.use('/api/*', (_req, res) =>
+    res.status(404).type('application/json').json({ error: 'Not Found' }),
+  );
 
-  app.use(ErrorController);
+  app.use((err, _req, res, _next) => {
+    const status = err.status || err.statusCode || 500;
+    const message = err.expose ? err.message : err.message || 'Internal Server Error';
+    res.status(status).type('application/json').json({ error: message });
+  });
 
   app.use((req, res) => {
     res.set({

--- a/client/src/lib/http-client.ts
+++ b/client/src/lib/http-client.ts
@@ -1,0 +1,32 @@
+export type Json = Record<string, unknown> | unknown[];
+
+export async function getJSON(input: RequestInfo, init?: RequestInit): Promise<Json> {
+  const res = await fetch(input, { credentials: 'include', ...init });
+  const ct = res.headers.get('content-type') || '';
+  const raw = await res.text();
+
+  if (!res.ok) {
+    const brief = raw.slice(0, 300);
+    throw new Error(`${res.status} ${res.statusText}${brief ? `: ${brief}` : ''}`);
+  }
+
+  if (ct.includes('application/json')) {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      throw new Error('Invalid JSON in successful response');
+    }
+  }
+
+  // Non-JSON success: return empty object to keep callers safe
+  return {};
+}
+
+export async function postJSON(url: string, body?: unknown, init?: RequestInit): Promise<Json> {
+  return getJSON(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...(init?.headers || {}) },
+    body: body == null ? undefined : JSON.stringify(body),
+    ...init,
+  });
+}

--- a/client/src/pages/AgentsList.tsx
+++ b/client/src/pages/AgentsList.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { getJSON } from '@/lib/http-client';
+
+export default function AgentsList() {
+  const [agents, setAgents] = useState<any[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    async function load() {
+      try {
+        const data1 = await getJSON('/api/agents?requiredPermission=1');
+        const data2 = await getJSON('/api/agents?requiredPermission=2');
+        if (!mounted) return;
+
+        const a1 = Array.isArray(data1) ? data1 : (data1 as any)?.items ?? [];
+        const a2 = Array.isArray(data2) ? data2 : (data2 as any)?.items ?? [];
+        setAgents([...a1, ...a2]);
+      } catch (e: any) {
+        console.error('Agents load failed:', e);
+        if (!mounted) return;
+        setError(e?.message ?? 'Failed to load agents');
+        setAgents([]); // safe empty state
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    }
+    load();
+    return () => { mounted = false; };
+  }, []);
+
+  if (loading) return <div>Loading agents…</div>;
+
+  return (
+    <div>
+      {error && (
+        <div role="alert" className="text-sm text-red-500 mb-3">
+          {error}
+        </div>
+      )}
+      {agents.length === 0 ? (
+        <div className="text-sm opacity-70">No agents available.</div>
+      ) : (
+        <ul className="space-y-2">
+          {agents.map((a) => (
+            <li key={a._id ?? a.id} className="border rounded p-2">
+              <div className="font-medium">{a.name ?? '(unnamed agent)'}</div>
+              <div className="text-xs opacity-70">{a.provider ?? '—'}</div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -9,6 +9,7 @@ import {
   RequestPasswordReset,
 } from '~/components/Auth';
 import AgentMarketplace from '~/components/Agents/Marketplace';
+import AgentsList from '~/pages/AgentsList';
 import { OAuthSuccess, OAuthError } from '~/components/OAuth';
 import { AuthContextProvider } from '~/hooks/AuthContext';
 import RouteErrorBoundary from './RouteErrorBoundary';
@@ -105,6 +106,10 @@ export const router = createBrowserRouter([
           {
             path: 'search',
             element: <Search />,
+          },
+          {
+            path: 'my-agents',
+            element: <AgentsList />,
           },
           {
             path: 'agents',


### PR DESCRIPTION
## Summary
- add `getJSON` helper with JSON/content-type checks
- wire My Agents page to use `getJSON`
- ensure `/api` routes return JSON errors
- revert JSON error changes in image middleware, related tests, roles route, and error controller

## Testing
- `npm run test:client` *(fails: Cannot find module 'librechat-data-provider')*
- `npm run test:api` *(fails: Cannot find module '@librechat/api')*

------
https://chatgpt.com/codex/tasks/task_e_68b067718b7c832abc836c91f72031e0