### PR TITLE
feat: support vector store configuration

### DIFF
--- a/api/app/clients/tools/util/fileSearch.js
+++ b/api/app/clients/tools/util/fileSearch.js
@@ -15,12 +15,15 @@ const { getFiles } = require('~/models/File');
  * @param {string} [options.agentId] - The agent ID for file access control
  * @returns {Promise<{
  *   files: Array<{ file_id: string; filename: string }>,
+ *   vector_store_ids: Array<string>,
  *   toolContext: string
  * }>}
  */
 const primeFiles = async (options) => {
   const { tool_resources, req, agentId } = options;
   const file_ids = tool_resources?.[EToolResources.file_search]?.file_ids ?? [];
+  const vector_store_ids =
+    tool_resources?.[EToolResources.file_search]?.vector_store_ids ?? [];
   const agentResourceIds = new Set(file_ids);
   const resourceFiles = tool_resources?.[EToolResources.file_search]?.files ?? [];
 
@@ -62,7 +65,7 @@ const primeFiles = async (options) => {
     });
   }
 
-  return { files, toolContext };
+  return { files, vector_store_ids, toolContext };
 };
 
 /**
@@ -70,70 +73,55 @@ const primeFiles = async (options) => {
  * @param {Object} options
  * @param {ServerRequest} options.req
  * @param {Array<{ file_id: string; filename: string }>} options.files
+ * @param {Array<string>} [options.vector_store_ids]
  * @param {string} [options.entity_id]
  * @returns
  */
-const createFileSearchTool = async ({ req, files, entity_id }) => {
+const createFileSearchTool = async ({ req, files, vector_store_ids = [], entity_id }) => {
   return tool(
     async ({ query }) => {
-      if (files.length === 0) {
-        return 'No files to search. Instruct the user to add files for the search.';
+      if (files.length === 0 && vector_store_ids.length === 0) {
+        return 'No files or vector stores to search. Instruct the user to add resources for the search.';
       }
       const jwtToken = generateShortLivedToken(req.user.id);
       if (!jwtToken) {
         return 'There was an error authenticating the file search request.';
       }
-
-      /**
-       *
-       * @param {import('librechat-data-provider').TFile} file
-       * @returns {{ file_id: string, query: string, k: number, entity_id?: string }}
-       */
-      const createQueryBody = (file) => {
-        const body = {
-          file_id: file.file_id,
-          query,
-          k: 5,
-        };
-        if (!entity_id) {
-          return body;
-        }
-        body.entity_id = entity_id;
-        logger.debug(`[${Tools.file_search}] RAG API /query body`, body);
-        return body;
+      const body = {
+        query,
+        k: 5,
+        file_ids: files.map((file) => file.file_id),
+        vector_store_ids,
       };
+      if (entity_id) {
+        body.entity_id = entity_id;
+      }
+      logger.debug(`[${Tools.file_search}] RAG API /query body`, body);
 
-      const queryPromises = files.map((file) =>
-        axios
-          .post(`${process.env.RAG_API_URL}/query`, createQueryBody(file), {
-            headers: {
-              Authorization: `Bearer ${jwtToken}`,
-              'Content-Type': 'application/json',
-            },
-          })
-          .catch((error) => {
-            logger.error('Error encountered in `file_search` while querying file:', error);
-            return null;
-          }),
-      );
+      const result = await axios
+        .post(`${process.env.RAG_API_URL}/query`, body, {
+          headers: {
+            Authorization: `Bearer ${jwtToken}`,
+            'Content-Type': 'application/json',
+          },
+        })
+        .catch((error) => {
+          logger.error('Error encountered in `file_search` while querying files:', error);
+          return null;
+        });
 
-      const results = await Promise.all(queryPromises);
-      const validResults = results.filter((result) => result !== null);
-
-      if (validResults.length === 0) {
+      if (!result || !Array.isArray(result.data) || result.data.length === 0) {
         return 'No results found or errors occurred while searching the files.';
       }
 
-      const formattedResults = validResults
-        .flatMap((result, fileIndex) =>
-          result.data.map(([docInfo, distance]) => ({
-            filename: docInfo.metadata.source.split('/').pop(),
-            content: docInfo.page_content,
-            distance,
-            file_id: files[fileIndex]?.file_id,
-            page: docInfo.metadata.page || null,
-          })),
-        )
+      const formattedResults = result.data
+        .map(([docInfo, distance]) => ({
+          filename: docInfo.metadata.source.split('/').pop(),
+          content: docInfo.page_content,
+          distance,
+          file_id: docInfo.metadata.file_id || docInfo.file_id,
+          page: docInfo.metadata.page || null,
+        }))
         // TODO: results should be sorted by relevance, not distance
         .sort((a, b) => a.distance - b.distance)
         // TODO: make this configurable

--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -261,14 +261,19 @@ const loadTools = async ({
       continue;
     } else if (tool === Tools.file_search) {
       requestedTools[tool] = async () => {
-        const { files, toolContext } = await primeSearchFiles({
+        const { files, vector_store_ids, toolContext } = await primeSearchFiles({
           ...options,
           agentId: agent?.id,
         });
         if (toolContext) {
           toolContextMap[tool] = toolContext;
         }
-        return createFileSearchTool({ req: options.req, files, entity_id: agent?.id });
+        return createFileSearchTool({
+          req: options.req,
+          files,
+          vector_store_ids,
+          entity_id: agent?.id,
+        });
       };
       continue;
     } else if (tool === Tools.web_search) {

--- a/api/server/services/Endpoints/agents/agent.js
+++ b/api/server/services/Endpoints/agents/agent.js
@@ -89,6 +89,7 @@ const initializeAgent = async ({
     requestFileSet: new Set(requestFiles?.map((file) => file.file_id)),
     agentId: agent.id,
   });
+  agent.tool_resources = tool_resources;
 
   const provider = agent.provider;
   const { tools: structuredTools, toolContextMap } =
@@ -190,6 +191,7 @@ const initializeAgent = async ({
     attachments,
     resendFiles,
     toolContextMap,
+    tool_resources,
     useLegacyContent: !!options.useLegacyContent,
     maxContextTokens: Math.round((agentMaxContextTokens - maxTokens) * 0.9),
   };

--- a/client/src/common/agents-types.ts
+++ b/client/src/common/agents-types.ts
@@ -37,5 +37,6 @@ export type AgentForm = {
   [AgentCapabilities.artifacts]?: ArtifactModes | string;
   recursion_limit?: number;
   support_contact?: SupportContact;
+  vector_store_ids?: string;
   category: string;
 } & TAgentCapabilities;

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -181,31 +181,41 @@ export default function AgentPanel() {
         recursion_limit,
         category,
         support_contact,
+        vector_store_ids,
       } = data;
 
       const model = _model ?? '';
       const provider =
         (typeof _provider === 'string' ? _provider : (_provider as StringOption).value) ?? '';
 
+      const vectorStoreIds = vector_store_ids
+        ?.split(',')
+        .map((id) => id.trim())
+        .filter((id) => id);
+
       if (agent_id) {
+        const updateData: any = {
+          name,
+          artifacts,
+          description,
+          instructions,
+          model,
+          tools,
+          provider,
+          model_parameters,
+          agent_ids,
+          end_after_tools,
+          hide_sequential_outputs,
+          recursion_limit,
+          category,
+          support_contact,
+        };
+        if (vectorStoreIds && vectorStoreIds.length) {
+          updateData['tool_resources.file_search.vector_store_ids'] = vectorStoreIds;
+        }
         update.mutate({
           agent_id,
-          data: {
-            name,
-            artifacts,
-            description,
-            instructions,
-            model,
-            tools,
-            provider,
-            model_parameters,
-            agent_ids,
-            end_after_tools,
-            hide_sequential_outputs,
-            recursion_limit,
-            category,
-            support_contact,
-          },
+          data: updateData,
         });
         return;
       }
@@ -223,7 +233,7 @@ export default function AgentPanel() {
         });
       }
 
-      create.mutate({
+      const createData: any = {
         name,
         artifacts,
         description,
@@ -238,7 +248,11 @@ export default function AgentPanel() {
         recursion_limit,
         category,
         support_contact,
-      });
+      };
+      if (vectorStoreIds && vectorStoreIds.length) {
+        createData.tool_resources = { file_search: { vector_store_ids: vectorStoreIds } };
+      }
+      create.mutate(createData);
     },
     [agent_id, create, update, showToast, localize],
   );

--- a/client/src/components/SidePanel/Agents/AgentSelect.tsx
+++ b/client/src/components/SidePanel/Agents/AgentSelect.tsx
@@ -83,6 +83,11 @@ export default function AgentSelect({
         support_contact: fullAgent.support_contact,
       };
 
+      const vectorIds = fullAgent.tool_resources?.file_search?.vector_store_ids;
+      if (Array.isArray(vectorIds) && vectorIds.length > 0) {
+        formValues.vector_store_ids = vectorIds.join(', ');
+      }
+
       Object.entries(fullAgent).forEach(([name, value]) => {
         if (name === 'model_parameters') {
           formValues[name] = value;

--- a/client/src/components/SidePanel/Agents/FileSearch.tsx
+++ b/client/src/components/SidePanel/Agents/FileSearch.tsx
@@ -28,7 +28,7 @@ export default function FileSearch({
 }) {
   const localize = useLocalize();
   const { setFilesLoading } = useChatContext();
-  const { watch } = useFormContext<AgentForm>();
+  const { watch, register } = useFormContext<AgentForm>();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [files, setFiles] = useState<Map<string, ExtendedFile>>(new Map());
   const [isPopoverActive, setIsPopoverActive] = useState(false);
@@ -134,6 +134,17 @@ export default function FileSearch({
       </div>
       <FileSearchCheckbox />
       <div className="flex flex-col gap-3">
+        <div className="flex w-full flex-col gap-1">
+          <label className="text-token-text-primary block font-medium">
+            {localize('com_agents_vector_store_ids')}
+          </label>
+          <input
+            type="text"
+            className="border-token-border-light bg-surface-secondary text-token-text-primary h-9 w-full rounded-lg px-3 py-2"
+            placeholder={localize('com_agents_vector_store_ids_placeholder')}
+            {...register('vector_store_ids')}
+          />
+        </div>
         {/* File Search (RAG API) Files */}
         <FileRow
           files={files}

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -48,6 +48,8 @@
   "com_agents_file_context_info": "Files uploaded as \"Context\" are processed using OCR to extract text, which is then added to the Agent's instructions. Ideal for documents, images with text, or PDFs where you need the full text content of a file",
   "com_agents_file_search_disabled": "Agent must be created before uploading files for File Search.",
   "com_agents_file_search_info": "When enabled, the agent will be informed of the exact filenames listed below, allowing it to retrieve relevant context from these files.",
+  "com_agents_vector_store_ids": "Vector Store IDs",
+  "com_agents_vector_store_ids_placeholder": "Comma-separated vector store IDs",
   "com_agents_grid_announcement": "Showing {{count}} agents in {{category}} category",
   "com_agents_instructions_placeholder": "The system instructions that the agent uses",
   "com_agents_link_copied": "Link copied",

--- a/packages/api/src/agents/resources.ts
+++ b/packages/api/src/agents/resources.ts
@@ -181,7 +181,7 @@ export const primeResources = async ({
      * The agent's tool resources object that will be updated with categorized files
      * Initialized from input parameter or empty object if not provided
      */
-    const tool_resources = _tool_resources ?? {};
+    const tool_resources = structuredClone(_tool_resources ?? {});
 
     // Track existing files in tool_resources to prevent duplicates within resources
     for (const [resourceType, resource] of Object.entries(tool_resources)) {

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -183,6 +183,7 @@ export const defaultAgentFormValues = {
   [Tools.execute_code]: false,
   [Tools.file_search]: false,
   [Tools.web_search]: false,
+  vector_store_ids: '',
   category: 'general',
   support_contact: {
     name: '',

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -248,6 +248,7 @@ export type AgentCreateParams = {
   provider: AgentProvider;
   model: string | null;
   model_parameters: AgentModelParameters;
+  tool_resources?: ToolResources;
 } & Pick<
   Agent,
   | 'agent_ids'


### PR DESCRIPTION
## Summary
- allow file search tool to include vector stores in requests
- keep vector store IDs through agent initialization and priming
- add vector store configuration to agent editor UI and persist to agents

## Testing
- `npm test` (fails: Cannot find module '@librechat/data-schemas')
- `npm test` (fails: Cannot find module 'librechat-data-provider'; MongoDB download error)


------
https://chatgpt.com/codex/tasks/task_e_68b7ff4568dc832a98562f141a7c2523