### PR TITLE
Revert vector store ID handling changes

### DIFF
--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -261,19 +261,14 @@ const loadTools = async ({
       continue;
     } else if (tool === Tools.file_search) {
       requestedTools[tool] = async () => {
-        const { files, vector_store_ids, toolContext } = await primeSearchFiles({
+        const { files, toolContext } = await primeSearchFiles({
           ...options,
           agentId: agent?.id,
         });
         if (toolContext) {
           toolContextMap[tool] = toolContext;
         }
-        return createFileSearchTool({
-          req: options.req,
-          files,
-          vector_store_ids,
-          entity_id: agent?.id,
-        });
+        return createFileSearchTool({ req: options.req, files, entity_id: agent?.id });
       };
       continue;
     } else if (tool === Tools.web_search) {

--- a/api/server/services/Endpoints/agents/agent.js
+++ b/api/server/services/Endpoints/agents/agent.js
@@ -89,7 +89,6 @@ const initializeAgent = async ({
     requestFileSet: new Set(requestFiles?.map((file) => file.file_id)),
     agentId: agent.id,
   });
-  agent.tool_resources = tool_resources;
 
   const provider = agent.provider;
   const { tools: structuredTools, toolContextMap } =
@@ -191,7 +190,6 @@ const initializeAgent = async ({
     attachments,
     resendFiles,
     toolContextMap,
-    tool_resources,
     useLegacyContent: !!options.useLegacyContent,
     maxContextTokens: Math.round((agentMaxContextTokens - maxTokens) * 0.9),
   };

--- a/client/src/common/agents-types.ts
+++ b/client/src/common/agents-types.ts
@@ -37,6 +37,5 @@ export type AgentForm = {
   [AgentCapabilities.artifacts]?: ArtifactModes | string;
   recursion_limit?: number;
   support_contact?: SupportContact;
-  vector_store_ids?: string;
   category: string;
 } & TAgentCapabilities;

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -181,41 +181,31 @@ export default function AgentPanel() {
         recursion_limit,
         category,
         support_contact,
-        vector_store_ids,
       } = data;
 
       const model = _model ?? '';
       const provider =
         (typeof _provider === 'string' ? _provider : (_provider as StringOption).value) ?? '';
 
-      const vectorStoreIds = vector_store_ids
-        ?.split(',')
-        .map((id) => id.trim())
-        .filter((id) => id);
-
       if (agent_id) {
-        const updateData: any = {
-          name,
-          artifacts,
-          description,
-          instructions,
-          model,
-          tools,
-          provider,
-          model_parameters,
-          agent_ids,
-          end_after_tools,
-          hide_sequential_outputs,
-          recursion_limit,
-          category,
-          support_contact,
-        };
-        if (vectorStoreIds && vectorStoreIds.length) {
-          updateData['tool_resources.file_search.vector_store_ids'] = vectorStoreIds;
-        }
         update.mutate({
           agent_id,
-          data: updateData,
+          data: {
+            name,
+            artifacts,
+            description,
+            instructions,
+            model,
+            tools,
+            provider,
+            model_parameters,
+            agent_ids,
+            end_after_tools,
+            hide_sequential_outputs,
+            recursion_limit,
+            category,
+            support_contact,
+          },
         });
         return;
       }
@@ -233,7 +223,7 @@ export default function AgentPanel() {
         });
       }
 
-      const createData: any = {
+      create.mutate({
         name,
         artifacts,
         description,
@@ -248,11 +238,7 @@ export default function AgentPanel() {
         recursion_limit,
         category,
         support_contact,
-      };
-      if (vectorStoreIds && vectorStoreIds.length) {
-        createData.tool_resources = { file_search: { vector_store_ids: vectorStoreIds } };
-      }
-      create.mutate(createData);
+      });
     },
     [agent_id, create, update, showToast, localize],
   );

--- a/client/src/components/SidePanel/Agents/AgentSelect.tsx
+++ b/client/src/components/SidePanel/Agents/AgentSelect.tsx
@@ -83,11 +83,6 @@ export default function AgentSelect({
         support_contact: fullAgent.support_contact,
       };
 
-      const vectorIds = fullAgent.tool_resources?.file_search?.vector_store_ids;
-      if (Array.isArray(vectorIds) && vectorIds.length > 0) {
-        formValues.vector_store_ids = vectorIds.join(', ');
-      }
-
       Object.entries(fullAgent).forEach(([name, value]) => {
         if (name === 'model_parameters') {
           formValues[name] = value;

--- a/client/src/components/SidePanel/Agents/FileSearch.tsx
+++ b/client/src/components/SidePanel/Agents/FileSearch.tsx
@@ -28,7 +28,7 @@ export default function FileSearch({
 }) {
   const localize = useLocalize();
   const { setFilesLoading } = useChatContext();
-  const { watch, register } = useFormContext<AgentForm>();
+  const { watch } = useFormContext<AgentForm>();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [files, setFiles] = useState<Map<string, ExtendedFile>>(new Map());
   const [isPopoverActive, setIsPopoverActive] = useState(false);
@@ -134,17 +134,6 @@ export default function FileSearch({
       </div>
       <FileSearchCheckbox />
       <div className="flex flex-col gap-3">
-        <div className="flex w-full flex-col gap-1">
-          <label className="text-token-text-primary block font-medium">
-            {localize('com_agents_vector_store_ids')}
-          </label>
-          <input
-            type="text"
-            className="border-token-border-light bg-surface-secondary text-token-text-primary h-9 w-full rounded-lg px-3 py-2"
-            placeholder={localize('com_agents_vector_store_ids_placeholder')}
-            {...register('vector_store_ids')}
-          />
-        </div>
         {/* File Search (RAG API) Files */}
         <FileRow
           files={files}

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -48,8 +48,6 @@
   "com_agents_file_context_info": "Files uploaded as \"Context\" are processed using OCR to extract text, which is then added to the Agent's instructions. Ideal for documents, images with text, or PDFs where you need the full text content of a file",
   "com_agents_file_search_disabled": "Agent must be created before uploading files for File Search.",
   "com_agents_file_search_info": "When enabled, the agent will be informed of the exact filenames listed below, allowing it to retrieve relevant context from these files.",
-  "com_agents_vector_store_ids": "Vector Store IDs",
-  "com_agents_vector_store_ids_placeholder": "Comma-separated vector store IDs",
   "com_agents_grid_announcement": "Showing {{count}} agents in {{category}} category",
   "com_agents_instructions_placeholder": "The system instructions that the agent uses",
   "com_agents_link_copied": "Link copied",

--- a/packages/api/src/agents/resources.ts
+++ b/packages/api/src/agents/resources.ts
@@ -181,7 +181,7 @@ export const primeResources = async ({
      * The agent's tool resources object that will be updated with categorized files
      * Initialized from input parameter or empty object if not provided
      */
-    const tool_resources = structuredClone(_tool_resources ?? {});
+    const tool_resources = _tool_resources ?? {};
 
     // Track existing files in tool_resources to prevent duplicates within resources
     for (const [resourceType, resource] of Object.entries(tool_resources)) {

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -183,7 +183,6 @@ export const defaultAgentFormValues = {
   [Tools.execute_code]: false,
   [Tools.file_search]: false,
   [Tools.web_search]: false,
-  vector_store_ids: '',
   category: 'general',
   support_contact: {
     name: '',

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -248,7 +248,6 @@ export type AgentCreateParams = {
   provider: AgentProvider;
   model: string | null;
   model_parameters: AgentModelParameters;
-  tool_resources?: ToolResources;
 } & Pick<
   Agent,
   | 'agent_ids'


### PR DESCRIPTION
## Summary
- revert vector store ID support to restore previous file search behavior
- remove UI and translation references to vector store configuration

## Testing
- `npm run lint` *(fails: no output produced)*
- `npm run test:api` *(fails: Cannot find module '@librechat/data-schemas')*
- `npm run test:client` *(fails: Cannot find module '@librechat/client')*

------
https://chatgpt.com/codex/tasks/task_e_68b850f7d49c832a9f688802f395d187