### PR TITLE
Store agent tool configurations as objects

### DIFF
--- a/api/server/routes/agents/actions.js
+++ b/api/server/routes/agents/actions.js
@@ -132,8 +132,15 @@ router.post(
       const { tools: _tools = [] } = agent;
 
       const tools = _tools
-        .filter((tool) => !(tool && (tool.includes(domain) || tool.includes(action_id))))
-        .concat(functions.map((tool) => `${tool.function.name}${actionDelimiter}${domain}`));
+        .filter((tool) => {
+          const toolName = typeof tool === 'string' ? tool : tool.type;
+          return !(toolName && (toolName.includes(domain) || toolName.includes(action_id)));
+        })
+        .concat(
+          functions.map(
+            (tool) => `${tool.function.name}${actionDelimiter}${domain}`,
+          ),
+        );
 
       // Force version update since actions are changing
       const updatedAgent = await updateAgent(
@@ -212,7 +219,10 @@ router.delete(
         return res.status(400).json({ message: 'No domain provided' });
       }
 
-      const updatedTools = tools.filter((tool) => !(tool && tool.includes(domain)));
+      const updatedTools = tools.filter((tool) => {
+        const toolName = typeof tool === 'string' ? tool : tool.type;
+        return !(toolName && toolName.includes(domain));
+      });
 
       // Force version update since actions are being removed
       await updateAgent(

--- a/api/server/services/Endpoints/agents/agent.js
+++ b/api/server/services/Endpoints/agents/agent.js
@@ -69,8 +69,9 @@ const initializeAgent = async ({
     /** @type {Set<EToolResources>} */
     const toolResourceSet = new Set();
     for (const tool of agent.tools) {
-      if (EToolResources[tool]) {
-        toolResourceSet.add(EToolResources[tool]);
+      const toolName = typeof tool === 'string' ? tool : tool.type;
+      if (EToolResources[toolName]) {
+        toolResourceSet.add(EToolResources[toolName]);
       }
     }
     const toolFiles = await getToolFilesByIds(fileIds, toolResourceSet);

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -476,7 +476,13 @@ async function processRequiredActions(client, requiredActions) {
 async function loadAgentTools({ req, res, agent, tool_resources, openAIApiKey }) {
   if (!agent.tools || agent.tools.length === 0) {
     return {};
-  } else if (agent.tools && agent.tools.length === 1 && agent.tools[0] === AgentCapabilities.ocr) {
+  } else if (
+    agent.tools &&
+    agent.tools.length === 1 &&
+    (typeof agent.tools[0] === 'string'
+      ? agent.tools[0]
+      : agent.tools[0].type) === AgentCapabilities.ocr
+  ) {
     return {};
   }
 
@@ -501,14 +507,15 @@ async function loadAgentTools({ req, res, agent, tool_resources, openAIApiKey })
 
   let includesWebSearch = false;
   const _agentTools = agent.tools?.filter((tool) => {
-    if (tool === Tools.file_search) {
+    const toolName = typeof tool === 'string' ? tool : tool.type;
+    if (toolName === Tools.file_search) {
       return checkCapability(AgentCapabilities.file_search);
-    } else if (tool === Tools.execute_code) {
+    } else if (toolName === Tools.execute_code) {
       return checkCapability(AgentCapabilities.execute_code);
-    } else if (tool === Tools.web_search) {
+    } else if (toolName === Tools.web_search) {
       includesWebSearch = checkCapability(AgentCapabilities.web_search);
       return includesWebSearch;
-    } else if (!areToolsEnabled && !tool.includes(actionDelimiter)) {
+    } else if (!areToolsEnabled && !toolName.includes(actionDelimiter)) {
       return false;
     }
     return true;

--- a/client/src/data-provider/Agents/mutations.ts
+++ b/client/src/data-provider/Agents/mutations.ts
@@ -298,7 +298,10 @@ export const useDeleteAgentAction = (
                 if (agent.id === variables.agent_id) {
                   return {
                     ...agent,
-                    tools: agent.tools?.filter((tool) => !tool.includes(domain ?? '')),
+                    tools: agent.tools?.filter((tool) => {
+                      const toolName = typeof tool === 'string' ? tool : tool.type;
+                      return !toolName.includes(domain ?? '');
+                    }),
                   };
                 }
                 return agent;
@@ -314,7 +317,10 @@ export const useDeleteAgentAction = (
 
         return {
           ...prev,
-          tools: prev.tools?.filter((tool) => !tool.includes(domain ?? '')),
+          tools: prev.tools?.filter((tool) => {
+            const toolName = typeof tool === 'string' ? tool : tool.type;
+            return !toolName.includes(domain ?? '');
+          }),
         };
       };
       queryClient.setQueryData<t.Agent>([QueryKeys.agent, variables.agent_id], updaterFn);

--- a/client/src/data-provider/Files/mutations.ts
+++ b/client/src/data-provider/Files/mutations.ts
@@ -78,8 +78,12 @@ export const useUploadFileMutation = (
             ...prevResources,
             [tool_resource]: prevResource,
           };
-          if (!agent.tools?.includes(tool_resource)) {
-            update['tools'] = [...(agent.tools ?? []), tool_resource];
+          if (
+            !agent.tools?.some(
+              (t) => (typeof t === 'string' ? t : t.type) === tool_resource,
+            )
+          ) {
+            update['tools'] = [...(agent.tools ?? []), { type: tool_resource }];
           }
           return {
             ...agent,

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -214,7 +214,7 @@ export type Agent = {
   avatar: AgentAvatar | null;
   instructions: string | null;
   additional_instructions?: string | null;
-  tools?: string[];
+  tools?: Array<FunctionTool | { type: string; [key: string]: unknown } | string>;
   projectIds?: string[];
   tool_kwargs?: Record<string, unknown>;
   metadata?: Record<string, unknown>;

--- a/packages/data-schemas/src/schema/agent.ts
+++ b/packages/data-schemas/src/schema/agent.ts
@@ -43,7 +43,7 @@ const agentSchema = new Schema<IAgent>(
       type: Number,
     },
     tools: {
-      type: [String],
+      type: [Schema.Types.Mixed],
       default: undefined,
     },
     tool_kwargs: {
@@ -81,7 +81,7 @@ const agentSchema = new Schema<IAgent>(
     },
     tool_resources: {
       type: Schema.Types.Mixed,
-      default: {},
+      default: undefined,
     },
     projectIds: {
       type: [Schema.Types.ObjectId],

--- a/packages/data-schemas/src/types/agent.ts
+++ b/packages/data-schemas/src/types/agent.ts
@@ -20,7 +20,7 @@ export interface IAgent extends Omit<Document, 'model'> {
   artifacts?: string;
   access_level?: number;
   recursion_limit?: number;
-  tools?: string[];
+  tools?: Array<string | { type: string; [key: string]: unknown }>;
   tool_kwargs?: Array<unknown>;
   actions?: string[];
   author: Types.ObjectId;


### PR DESCRIPTION
## Summary
- persist agent tools as full objects instead of string identifiers
- update API, services, and client mutations for new tool structure
- adjust data schemas to store mixed tool objects and omit empty tool resources

## Testing
- `npm run test:api` *(fails: Cannot find module '@librechat/api')*
- `npm run test:client` *(fails: Cannot find module '@librechat/client')*

------
https://chatgpt.com/codex/tasks/task_e_68c1ca420174832abb29ec13b5b51b5b