### PR TITLE
Return access token on refresh

### DIFF
--- a/api/routes/refresh.override.js
+++ b/api/routes/refresh.override.js
@@ -38,7 +38,7 @@ router.post('/api/auth/refresh', async (req, res) => {
     const userId = payload.sub;
 
     const User = mongoose.model('User');
-    const user = await User.findById(userId);
+    const user = await User.findById(userId).select('-password -__v -totpSecret -backupCodes');
     if (!user) return res.status(401).json({ ok: false, error: 'user-missing' });
 
     const access = jwt.sign(
@@ -62,7 +62,7 @@ router.post('/api/auth/refresh', async (req, res) => {
     });
 
     setAuthCookies(res, access, refresh);
-    return res.status(200).json({ ok: true });
+    return res.status(200).json({ ok: true, token: access, user });
   } catch (e) {
     clearAuthCookies(res);
     return res.status(401).json({ ok: false, error: 'invalid-refresh' });

--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -138,7 +138,7 @@ const AuthContextProvider = ({
     }
     refreshToken.mutate(undefined, {
       onSuccess: (data: t.TRefreshTokenResponse | undefined) => {
-        const { user, token = '' } = data ?? {};
+        const { user, token } = data ?? {};
         if (token) {
           setUserContext({ token, isAuthenticated: true, user });
         } else {


### PR DESCRIPTION
## Summary
- return access token and user in `/api/auth/refresh` JSON response
- keep client `silentRefresh` storing refreshed token

## Testing
- `npm run test:client`
- `npm run test:api` *(fails: Cannot find module '@librechat/api'; MongoDB memory server download error)*

------
https://chatgpt.com/codex/tasks/task_e_68c31efdf990832abe1d3549068cf75f