### PR TITLE
feat: support jwt cookie authentication

### DIFF
--- a/api/strategies/jwtStrategy.js
+++ b/api/strategies/jwtStrategy.js
@@ -3,11 +3,17 @@ const { SystemRoles } = require('librechat-data-provider');
 const { Strategy: JwtStrategy, ExtractJwt } = require('passport-jwt');
 const { getUserById, updateUser } = require('~/models');
 
+const cookieExtractor = (req) =>
+  req?.cookies?.jwt || req?.cookies?.token || req?.cookies?.accessToken || null;
+
 // JWT strategy
 const jwtLogin = () =>
   new JwtStrategy(
     {
-      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        cookieExtractor,
+        ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ]),
       secretOrKey: process.env.JWT_SECRET,
     },
     async (payload, done) => {

--- a/api/test/routes/userAuth.test.js
+++ b/api/test/routes/userAuth.test.js
@@ -1,0 +1,64 @@
+const express = require('express');
+const request = require('supertest');
+const passport = require('passport');
+const cookieParser = require('cookie-parser');
+const jwt = require('jsonwebtoken');
+
+jest.mock(
+  '@librechat/data-schemas',
+  () => ({
+    logger: {
+      warn: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+    },
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  'librechat-data-provider',
+  () => ({
+    SystemRoles: { USER: 'user' },
+  }),
+  { virtual: true },
+);
+
+jest.mock('~/models', () => ({
+  getUserById: jest.fn().mockResolvedValue({ _id: '123', role: 'user' }),
+  updateUser: jest.fn(),
+}));
+
+const jwtStrategy = require('~/strategies/jwtStrategy');
+
+const requireJwtAuth = (req, res, next) =>
+  passport.authenticate('jwt', { session: false })(req, res, next);
+
+const app = express();
+app.use(cookieParser());
+app.use(passport.initialize());
+passport.use(jwtStrategy());
+
+app.get('/api/user', requireJwtAuth, (req, res) => {
+  res.status(200).json({ id: req.user.id });
+});
+
+describe('/api/user authentication', () => {
+  it('returns 200 with Authorization header', async () => {
+    const token = jwt.sign({ id: '123' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .get('/api/user')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe('123');
+  });
+
+  it('returns 200 with jwt cookie', async () => {
+    const token = jwt.sign({ id: '123' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .get('/api/user')
+      .set('Cookie', [`jwt=${token}`]);
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe('123');
+  });
+});


### PR DESCRIPTION
## Summary
- allow JWT auth via cookies or Authorization header
- add tests ensuring `/api/user` accepts cookie or header tokens

## Testing
- `npm test` *(fails: Cannot find module '@librechat/data-schemas')*
- `npx jest test/routes/userAuth.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c324098a24832aa6df9fb72744a930