### PR TITLE
feat(magic): allow redirect to next param

### DIFF
--- a/api/routes/magic.js
+++ b/api/routes/magic.js
@@ -103,9 +103,10 @@ router.get('/m/signed', (req, res) => {
       return;
     }
 
-    console.log('[magic] success, redirecting to home');
-    // All good → go home (cache-busting param to defeat SW)
-    location.replace('/?from=magic&cb=' + Date.now());
+    const params = new URLSearchParams(location.search);
+    const next = params.get('next') || '/?from=magic&cb=' + Date.now();
+    console.log('[magic] success, redirecting to', next);
+    location.replace(next);
   })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- parse `next` query param in magic link handshake page
- redirect to provided path after tokens are stored

## Testing
- `npx eslint api/routes/magic.js`
- `npm run test:api` *(fails: Cannot find module '@librechat/api', '@librechat/data-schemas', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c40cd9a434832a8b4dc5b1e5ef2414