### PR TITLE
Add logging for agent link troubleshooting

### DIFF
--- a/client/src/components/Agents/AgentDetail.tsx
+++ b/client/src/components/Agents/AgentDetail.tsx
@@ -12,7 +12,7 @@ import {
 } from 'librechat-data-provider';
 import type t from 'librechat-data-provider';
 import { useChatContext } from '~/Providers';
-import { renderAgentAvatar } from '~/utils';
+import { renderAgentAvatar, logger } from '~/utils';
 import { useLocalize } from '~/hooks';
 
 interface SupportContact {
@@ -79,6 +79,8 @@ const AgentDetail: React.FC<AgentDetailProps> = ({ agent, isOpen, onClose }) => 
   const handleCopyLink = () => {
     const baseUrl = new URL(window.location.origin);
     const chatUrl = `${baseUrl.origin}/c/new?agent_id=${agent.id}`;
+    logger.debug('agents', 'Generated agent chat URL', { chatUrl });
+    console.log('AgentDetail copy link', { chatUrl });
     navigator.clipboard
       .writeText(chatUrl)
       .then(() => {

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { Spinner } from '@librechat/client';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 import { Constants, EModelEndpoint } from 'librechat-data-provider';
 import { useGetModelsQuery } from 'librechat-data-provider/react-query';
 import type { TPreset } from 'librechat-data-provider';
@@ -17,6 +17,18 @@ import store from '~/store';
 export default function ChatRoute() {
   const { data: startupConfig } = useGetStartupConfig();
   const { isAuthenticated, user } = useAuthRedirect();
+  const location = useLocation();
+
+  useEffect(() => {
+    logger.debug('navigation', 'ChatRoute location', {
+      pathname: location.pathname,
+      search: location.search,
+    });
+    console.log('ChatRoute location', {
+      pathname: location.pathname,
+      search: location.search,
+    });
+  }, [location]);
 
   const setIsTemporary = useRecoilCallback(
     ({ set }) =>
@@ -58,6 +70,12 @@ export default function ChatRoute() {
    *  Adjusting this may have unintended consequences on the conversation state.
    */
   useEffect(() => {
+    logger.debug('conversation', 'New conversation effect triggered', {
+      search: window.location.search,
+    });
+    console.log('ChatRoute new convo effect', {
+      search: window.location.search,
+    });
     const shouldSetConvo =
       (startupConfig && !hasSetConversation.current && !modelsQuery.data?.initial) ?? false;
     /* Early exit if startupConfig is not loaded and conversation is already set and only initial models have loaded */

--- a/client/src/routes/useAuthRedirect.ts
+++ b/client/src/routes/useAuthRedirect.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthContext } from '~/hooks';
+import { logger } from '~/utils';
 
 export default function useAuthRedirect() {
   const { user, isAuthenticated } = useAuthContext();
@@ -8,7 +9,12 @@ export default function useAuthRedirect() {
 
   useEffect(() => {
     const timeout = setTimeout(() => {
+      const { pathname, search } = window.location;
+      logger.debug('auth', 'useAuthRedirect effect', { pathname, search, isAuthenticated });
+      console.log('useAuthRedirect', { pathname, search, isAuthenticated });
       if (!isAuthenticated) {
+        logger.warn('auth', `Redirecting to login from ${pathname}${search}`);
+        console.log('useAuthRedirect redirect', { pathname, search });
         navigate('/login', { replace: true });
       }
     }, 300);


### PR DESCRIPTION
## Summary
- log redirect details in useAuthRedirect
- log navigation and query info in ChatRoute
- log generated agent link in AgentDetail

## Testing
- `npx eslint client/src/routes/useAuthRedirect.ts client/src/routes/ChatRoute.tsx client/src/components/Agents/AgentDetail.tsx`
- `npm run test:client` *(fails: Cannot find module 'librechat-data-provider')*

------
https://chatgpt.com/codex/tasks/task_e_68c444b864bc832aa5e20644a7423c58