### PR TITLE
Remove assistant configuration from librechat

### DIFF
--- a/librechat.yaml
+++ b/librechat.yaml
@@ -10,10 +10,3 @@ endpoints:
       text: true
       truncation: auto
 
-  assistants:
-    # show only this Assistant in the UI
-    supportedIds:
-      - "asst_SMtOqkDo9B8VmNaHtBw0eomL"
-    # do NOT combine privateAssistants with supportedIds
-    privateAssistants: false
-    disableBuilder: false


### PR DESCRIPTION
## Summary
- remove hardcoded assistant IDs from `librechat.yaml`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(terminated: no results)*

------
https://chatgpt.com/codex/tasks/task_e_68c4475cfe40832a95cb1e84a4f17710