### PR TITLE
Disable balance checks by default

### DIFF
--- a/api/routes/magic.js
+++ b/api/routes/magic.js
@@ -194,7 +194,9 @@ router.get('/m/:token', async (req, res) => {
     });
 
     // finish on the handshake page (writes localStorage + verifies /api/user)
-    return res.redirect('/m/signed');
+    const qsIndex = req.originalUrl.indexOf('?');
+    const qs = qsIndex > -1 ? req.originalUrl.slice(qsIndex) : '';
+    return res.redirect('/m/signed' + qs);
   } catch (e) {
     console.error('[magic] error', e && (e.stack || e.message || e));
     clearAuthCookies(res);

--- a/librechat.yaml
+++ b/librechat.yaml
@@ -10,3 +10,5 @@ endpoints:
       text: true
       truncation: auto
 
+balance:
+  enabled: false


### PR DESCRIPTION
## Summary
- disable balance feature in default configuration to avoid 404 balance requests when no record exists
- preserve `next` query string when redirecting magic links to `/m/signed`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint api/routes/magic.js`


------
https://chatgpt.com/codex/tasks/task_e_68c449c7cdd0832a81887c307e644564