### PR TITLE
Allow function tools for agents

### DIFF
--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -44,6 +44,7 @@ const systemTools = {
   [Tools.execute_code]: true,
   [Tools.file_search]: true,
   [Tools.web_search]: true,
+  [Tools.function]: true,
   mcp: true,
 };
 


### PR DESCRIPTION
## Summary
- add the OpenAI function tool type to the built-in system tools that agents may use

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca92c85724832ab999b669de88ec12