### PR TITLE
Ensure agent conversation starters appear in chat

### DIFF
--- a/api/models/Agent.js
+++ b/api/models/Agent.js
@@ -578,6 +578,7 @@ const getListAgentsByAccess = async ({
     name: 1,
     avatar: 1,
     author: 1,
+    conversation_starters: 1,
     projectIds: 1,
     description: 1,
     updatedAt: 1,

--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -179,6 +179,7 @@ const getAgentHandler = async (req, res, expandProperties = false) => {
         author: agent.author,
         provider: agent.provider,
         model: agent.model,
+        conversation_starters: agent.conversation_starters ?? [],
         projectIds: agent.projectIds,
         // @deprecated - isCollaborative replaced by ACL permissions
         isCollaborative: agent.isCollaborative,


### PR DESCRIPTION
## Summary
- include `conversation_starters` in the agent list projection so UI receives starter prompts
- expose `conversation_starters` in the basic agent details response returned by GET /agents/:id

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7f5d931a4832aa292c01b124b33ee