### PR TITLE
Increase conversation starter input height

### DIFF
--- a/client/src/components/SidePanel/Builder/AssistantConversationStarters.tsx
+++ b/client/src/components/SidePanel/Builder/AssistantConversationStarters.tsx
@@ -71,7 +71,7 @@ const AssistantConversationStarters: React.FC<AssistantConversationStartersProps
             ref={(el) => (inputRefs.current[0] = el)}
             value={newStarter}
             maxLength={64}
-            className={`${inputClass} pr-10`}
+            className={`${inputClass} pr-10 py-[0.65rem]`}
             type="text"
             placeholder={
               hasReachedMax
@@ -133,7 +133,7 @@ const AssistantConversationStarters: React.FC<AssistantConversationStartersProps
                 newValue[index] = e.target.value;
                 field.onChange(newValue);
               }}
-              className={`${inputClass} pr-10`}
+              className={`${inputClass} pr-10 py-[0.65rem]`}
               type="text"
               maxLength={64}
             />


### PR DESCRIPTION
## Summary
- increase the conversation starter input padding to make each box 30% taller

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d94d399bc0832abcfeffc06be1ce11