### PR TITLE
Improve conversation starter display

### DIFF
--- a/client/src/components/Chat/Input/ConversationStarters.tsx
+++ b/client/src/components/Chat/Input/ConversationStarters.tsx
@@ -71,9 +71,9 @@ const ConversationStarters = () => {
           <button
             key={index}
             onClick={() => sendConversationStarter(text)}
-            className="relative flex w-40 cursor-pointer flex-col gap-2 rounded-2xl border border-border-medium px-3 pb-4 pt-3 text-start align-top text-[15px] shadow-[0_0_2px_0_rgba(0,0,0,0.05),0_4px_6px_0_rgba(0,0,0,0.02)] transition-colors duration-300 ease-in-out fade-in hover:bg-surface-tertiary"
+            className="relative flex min-w-[18rem] max-w-md cursor-pointer flex-1 flex-col gap-2 rounded-2xl border border-border-medium px-3 pb-4 pt-3 text-left align-top text-[15px] shadow-[0_0_2px_0_rgba(0,0,0,0.05),0_4px_6px_0_rgba(0,0,0,0.02)] transition-colors duration-300 ease-in-out fade-in hover:bg-surface-tertiary"
           >
-            <p className="break-word line-clamp-3 overflow-hidden text-balance break-all text-text-secondary">
+            <p className="whitespace-pre-wrap break-words text-text-secondary">
               {text}
             </p>
           </button>

--- a/client/src/components/SidePanel/Builder/AssistantConversationStarters.tsx
+++ b/client/src/components/SidePanel/Builder/AssistantConversationStarters.tsx
@@ -70,7 +70,7 @@ const AssistantConversationStarters: React.FC<AssistantConversationStartersProps
           <input
             ref={(el) => (inputRefs.current[0] = el)}
             value={newStarter}
-            maxLength={64}
+            maxLength={Constants.MAX_CONVO_STARTER_LENGTH}
             className={`${inputClass} pr-10 py-[0.65rem]`}
             type="text"
             placeholder={
@@ -135,7 +135,7 @@ const AssistantConversationStarters: React.FC<AssistantConversationStartersProps
               }}
               className={`${inputClass} pr-10 py-[0.65rem]`}
               type="text"
-              maxLength={64}
+              maxLength={Constants.MAX_CONVO_STARTER_LENGTH}
             />
             <TooltipAnchor
               side="top"

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1545,6 +1545,8 @@ export enum Constants {
   SAVED_TAG = 'Saved',
   /** Max number of Conversation starters for Agents/Assistants */
   MAX_CONVO_STARTERS = 4,
+  /** Max length for a single Conversation starter */
+  MAX_CONVO_STARTER_LENGTH = 160,
   /** Global/instance Project Name */
   GLOBAL_PROJECT_NAME = 'instance',
   /** Delimiter for MCP tools */


### PR DESCRIPTION
## Summary
- widen conversation starter cards and allow their text to wrap naturally so prompts are fully visible
- increase the maximum conversation starter length via a shared constant so creators can write longer prompts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d950523084832a87f59b069508e586