### PR TITLE
Fix RTL rendering for conversation starter cards

### DIFF
--- a/client/src/components/Chat/Input/ConversationStarters.tsx
+++ b/client/src/components/Chat/Input/ConversationStarters.tsx
@@ -71,9 +71,9 @@ const ConversationStarters = () => {
           <button
             key={index}
             onClick={() => sendConversationStarter(text)}
-            className="relative flex min-w-[18rem] max-w-md cursor-pointer flex-1 flex-col gap-2 rounded-2xl border border-border-medium px-3 pb-4 pt-3 text-left align-top text-[15px] shadow-[0_0_2px_0_rgba(0,0,0,0.05),0_4px_6px_0_rgba(0,0,0,0.02)] transition-colors duration-300 ease-in-out fade-in hover:bg-surface-tertiary"
+            className="relative flex min-w-[18rem] max-w-md cursor-pointer flex-1 flex-col gap-2 rounded-2xl border border-border-medium px-3 pb-4 pt-3 text-start align-top text-[15px] shadow-[0_0_2px_0_rgba(0,0,0,0.05),0_4px_6px_0_rgba(0,0,0,0.02)] transition-colors duration-300 ease-in-out fade-in hover:bg-surface-tertiary"
           >
-            <p className="whitespace-pre-wrap break-words text-text-secondary">
+            <p dir="auto" className="whitespace-pre-wrap break-words text-start text-text-secondary">
               {text}
             </p>
           </button>


### PR DESCRIPTION
## Summary
- adjust conversation starter buttons to align text based on writing direction
- ensure conversation starter copy respects right-to-left languages via automatic direction

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcd026e71c832a8290f14c4f454bb8