### PR TITLE
Revert RTL alignment changes for conversation starters

### DIFF
--- a/client/src/components/Chat/Input/ConversationStarters.tsx
+++ b/client/src/components/Chat/Input/ConversationStarters.tsx
@@ -71,9 +71,9 @@ const ConversationStarters = () => {
           <button
             key={index}
             onClick={() => sendConversationStarter(text)}
-            className="relative flex min-w-[18rem] max-w-md cursor-pointer flex-1 flex-col gap-2 rounded-2xl border border-border-medium px-3 pb-4 pt-3 text-start align-top text-[15px] shadow-[0_0_2px_0_rgba(0,0,0,0.05),0_4px_6px_0_rgba(0,0,0,0.02)] transition-colors duration-300 ease-in-out fade-in hover:bg-surface-tertiary"
+            className="relative flex min-w-[18rem] max-w-md cursor-pointer flex-1 flex-col gap-2 rounded-2xl border border-border-medium px-3 pb-4 pt-3 text-left align-top text-[15px] shadow-[0_0_2px_0_rgba(0,0,0,0.05),0_4px_6px_0_rgba(0,0,0,0.02)] transition-colors duration-300 ease-in-out fade-in hover:bg-surface-tertiary"
           >
-            <p dir="auto" className="whitespace-pre-wrap break-words text-start text-text-secondary">
+            <p className="whitespace-pre-wrap break-words text-text-secondary">
               {text}
             </p>
           </button>


### PR DESCRIPTION
## Summary
- revert the conversation starter button and text alignment to the pre-alignment state
- remove the auto direction attribute introduced for the RTL alignment change

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcd9b7f31c832abccefe901b55dbd5