### PR TITLE
Fix service worker login blank page by caching index.html

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -46,7 +46,7 @@ export default defineConfig(({ command }) => ({
           'assets/maskable-icon.png',
           'manifest.webmanifest',
         ],
-        globIgnores: ['images/**/*', '**/*.map', 'index.html'],
+        globIgnores: ['images/**/*', '**/*.map'],
         maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
         navigateFallbackDenylist: [/^\/oauth/, /^\/api/],
       },


### PR DESCRIPTION
## Summary
- ensure Workbox precaches index.html so navigations after login no longer error

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68dd0025082c832a882728709af1766f