### PR TITLE
Revert local storage auth key filtering

### DIFF
--- a/client/src/utils/localStorage.ts
+++ b/client/src/utils/localStorage.ts
@@ -26,7 +26,6 @@ export function getLocalStorageItems() {
 
 export function clearLocalStorage(skipFirst?: boolean) {
   const keys = Object.keys(localStorage);
-  const authKeys = new Set(['token', 'jwt', 'accessToken', 'refreshToken', 'loggedIn', 'userId', 'auth']);
   keys.forEach((key) => {
     if (skipFirst === true && key.endsWith('0')) {
       return;
@@ -40,8 +39,7 @@ export function clearLocalStorage(skipFirst?: boolean) {
       key === LocalStorageKeys.LAST_SPEC ||
       key === LocalStorageKeys.LAST_TOOLS ||
       key === LocalStorageKeys.LAST_MODEL ||
-      key === LocalStorageKeys.FILES_TO_DELETE ||
-      authKeys.has(key)
+      key === LocalStorageKeys.FILES_TO_DELETE
     ) {
       localStorage.removeItem(key);
     }


### PR DESCRIPTION
## Summary
- revert the merge that introduced auth key filtering in `clearLocalStorage`
- restore previous local storage clearing behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd04ae1810832aa00c6ba400bfb597