### PR TITLE
Ensure agents remain visible when model selection is disabled

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/ModelSelector.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/ModelSelector.tsx
@@ -53,6 +53,10 @@ function ModelSelectorContent() {
     [localize, agentsMap, modelSpecs, selectedValues, mappedEndpoints],
   );
 
+  if ((mappedEndpoints?.length ?? 0) === 0 && modelSpecs.length === 0) {
+    return null;
+  }
+
   const trigger = (
     <button
       className="my-1 flex h-10 w-full max-w-[70vw] items-center justify-center gap-2 rounded-xl border border-border-light bg-surface-secondary px-3 py-2 text-sm text-text-primary hover:bg-surface-tertiary"

--- a/client/src/hooks/Endpoint/useEndpoints.ts
+++ b/client/src/hooks/Endpoint/useEndpoints.ts
@@ -54,22 +54,35 @@ export const useEndpoints = ({
   );
 
   const filteredEndpoints = useMemo(() => {
-    if (!interfaceConfig.modelSelect) {
+    const showAgentsOnly = interfaceConfig.agents === true && interfaceConfig.modelSelect !== true;
+
+    if (!interfaceConfig.modelSelect && !showAgentsOnly) {
       return [];
     }
     const result: EModelEndpoint[] = [];
     for (let i = 0; i < endpoints.length; i++) {
+      if (showAgentsOnly && endpoints[i] !== EModelEndpoint.agents) {
+        continue;
+      }
       if (endpoints[i] === EModelEndpoint.agents && !hasAgentAccess) {
         continue;
       }
       if (includedEndpoints.size > 0 && !includedEndpoints.has(endpoints[i])) {
-        continue;
+        if (!(showAgentsOnly && endpoints[i] === EModelEndpoint.agents)) {
+          continue;
+        }
       }
       result.push(endpoints[i]);
     }
 
     return result;
-  }, [endpoints, hasAgentAccess, includedEndpoints, interfaceConfig.modelSelect]);
+  }, [
+    endpoints,
+    hasAgentAccess,
+    includedEndpoints,
+    interfaceConfig.agents,
+    interfaceConfig.modelSelect,
+  ]);
 
   const endpointRequiresUserKey = useCallback(
     (ep: string) => {


### PR DESCRIPTION
## Summary
- update endpoint filtering so the agents endpoint remains available when model selection is disabled
- hide the model selector trigger when no endpoints or specs are available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1326e51c4832a83a593ea68877a45